### PR TITLE
Remove Range package dependency

### DIFF
--- a/src/EasyTestFile.Json/EasyTestFile.Json.csproj
+++ b/src/EasyTestFile.Json/EasyTestFile.Json.csproj
@@ -14,8 +14,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\EasyTestFile\EasyTestFile.csproj" PrivateAssets="None" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
-	</ItemGroup>
 </Project>

--- a/src/EasyTestFile.Nunit/EasyTestFile.Nunit.csproj
+++ b/src/EasyTestFile.Nunit/EasyTestFile.Nunit.csproj
@@ -14,8 +14,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\EasyTestFile\EasyTestFile.csproj" PrivateAssets="None" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
-	</ItemGroup>
 </Project>

--- a/src/EasyTestFile.Xunit/EasyTestFile.Xunit.csproj
+++ b/src/EasyTestFile.Xunit/EasyTestFile.Xunit.csproj
@@ -16,8 +16,4 @@
 	<ItemGroup>
 		<ProjectReference Include="..\EasyTestFile\EasyTestFile.csproj" PrivateAssets="None" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
-	</ItemGroup>
 </Project>

--- a/src/EasyTestFile/EasyTestFile.csproj
+++ b/src/EasyTestFile/EasyTestFile.csproj
@@ -12,10 +12,6 @@
 		<Content Include="buildTransitive\EasyTestFile.targets" PackagePath="buildTransitive\EasyTestFile.targets" />
 	</ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.244" />
-    </ItemGroup>
-
 	<Choose>
 		<When Condition=" $(TargetFramework)=='netstandard2.1' OR $(TargetFramework)=='net5' OR $(TargetFramework)=='net6' ">
 			<PropertyGroup>
@@ -25,7 +21,6 @@
 
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="IndexRange" Version="1.0.0" PrivateAssets="all" />
 				<PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
 			</ItemGroup>
 		</Otherwise>

--- a/src/EasyTestFile/Guard.cs
+++ b/src/EasyTestFile/Guard.cs
@@ -90,7 +90,7 @@ internal static class Guard
             throw new ArgumentException($"Value: {value} starts with an invalid character (space)", argumentName);
         }
 
-        if (value[IndexFromEnd(1)] == invalidChar)
+        if (value[value.Length - 1] == invalidChar)
         {
             throw new ArgumentException($"Value: {value} ends with an invalid character (space)", argumentName);
         }
@@ -106,18 +106,5 @@ internal static class Guard
         {
             throw new ArgumentException($"Value: {value} contains an invalid character ('{invalidChar}')", argumentName);
         }
-    }
-    
-    /// <summary>Create an Index from the end at the position indicated by the value.</summary>
-    /// <param name="value">The index value from the end.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static Index IndexFromEnd(int value)
-    {
-        if (value < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
-        }
-
-        return new Index(value, true);
     }
 }

--- a/src/EasyTestFile/Internals/FileNameResolver.cs
+++ b/src/EasyTestFile/Internals/FileNameResolver.cs
@@ -9,7 +9,7 @@ internal static class FileNameResolver
         var physicalFilename = testMethodInfo.SanitizedFullSourceFile;
         if (physicalFilename.EndsWith(".cs"))
         {
-            physicalFilename = physicalFilename[..(testMethodInfo.SanitizedFullSourceFile.Length - 3)];
+            physicalFilename = physicalFilename.Substring(0, physicalFilename.Length - 3);
         }
 
         var suffix = string.Empty;


### PR DESCRIPTION
When using the package, i've got an FileNotFound exception. 

This PR completely removes the dependency for the Range nuget package (for netstandard20)

> System.IO.FileNotFoundException
> Could not load file or assembly 'IndexRange, Version=1.0.0.0, Culture=neutral, PublicKeyToken=35e6a3c4212514c6'. The system cannot find the file specified.
>    at EasyTestFile.Guard.AgainstBadMethodName(String value, String argumentName)
>    at EasyTestFile.TestMethodInfo..ctor(String sourceFile, String method)
>    at EasyTestFileNunit.Internal.TestFileFactory.Create(EasyTestFileSettings settings, Assembly testAssembly, MethodInfo methodInfo, String sourceFile, String method)
>    at EasyTestFileNunit.Internal.TestFileFactory.Create(EasyTestFileSettings settings, String sourceFile, String method)
> 